### PR TITLE
Set-up ReadME, Add release manager workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,508 @@
+name: Open Horizon Release Manager
+
+on:
+  workflow_dispatch:
+    inputs:
+      VERSION_JSON_FILE:
+        description: "The version json file, check the ReadME for formatting instructions if you are attempting to generate it yourself"
+        required: true
+        type: string
+      INCREMENT_MAJOR_VERSION:
+        description: "Should the major (X.0.0) version be incremented?"
+        required: true
+        type: boolean
+        default: false
+      INCREMENT_MINOR_VERSION:
+        description: "Should the minor (0.X.0) version be incremented?"
+        required: true
+        type: boolean
+        default: false
+      INCREMENT_PATCH_VERSION:
+        description: "Should the patch (0.0.X) version be incremented?"
+        required: true
+        type: boolean
+        default: true
+      IS_LATEST:
+        description: "Should we push the latest Dockerhub tags and mark releases as latest"
+        required: true
+        type: boolean
+        default: true
+
+env:
+  GITHUB_REST_API_VERSION: 2022-11-28
+  # Anax repo release manager variables
+  ANAX_REPOSITORY_OWNER: ${{ github.repository_owner }}
+  ANAX_REPOSITORY_NAME: anax
+  ANAX_RELEASE_MANAGER_FILE_NAME: release.yml
+  ANAX_RELEASE_ENVIRONMENT_NAME: release_environment
+  ANAX_RELEASE_MANAGER_BRANCH: master
+  # Examples repo release manager variables
+  EXAMPLES_REPOSITORY_OWNER: ${{ github.repository_owner }}
+  EXAMPLES_REPOSITORY_NAME: examples
+  EXAMPLES_RELEASE_MANAGER_FILE_NAME: release.yml
+  EXAMPLES_RELEASE_ENVIRONMENT_NAME: release_environment
+  EXAMPLES_RELEASE_MANAGER_BRANCH: master
+
+  # Needs 'repo' scope for org or anax,examples
+  OPENHORIZON_RELEASE_MANAGER_TOKEN: ${{ secrets.OPENHORIZON_RELEASE_MANAGER_TOKEN }}
+
+jobs:
+
+  release:
+    runs-on: ubuntu-20.04
+
+    environment: release_environment
+
+    steps:
+      # Based on user input, increment the OH semantic version variable found in the repo action variables
+      - name: Increment Open Horizon Release Version
+        id: update_version
+        run: |
+          # Use conditional statement to check what version is being incremented in order of precedence
+          if [[ "$INCREMENT_MAJOR_VERSION" = true ]]; then
+            IFS='.' read -r major minor patch <<< "$OPENHORIZON_RELEASE_VERSION"
+            major=$((major+1))
+            minor=0
+            patch=0
+            NEW_RELEASE="$major.$minor.$patch"
+          elif [[ "$INCREMENT_MINOR_VERSION" = true ]]; then
+            IFS='.' read -r major minor patch <<< "$OPENHORIZON_RELEASE_VERSION"
+            minor=$((minor+1))
+            patch=0
+            NEW_RELEASE="$major.$minor.$patch"
+          elif [[ "$INCREMENT_PATCH_VERSION" = true ]]; then
+            IFS='.' read -r major minor patch <<< "$OPENHORIZON_RELEASE_VERSION"
+            patch=$((patch+1))
+            NEW_RELEASE="$major.$minor.$patch"
+          else
+            echo "::warning::No version increment flag set."
+            NEW_RELEASE="$OPENHORIZON_RELEASE_VERSION"
+            exit 0
+          fi
+
+          # Our new release version is sent to actions output to be used by the release step later
+          echo "NEW_RELEASE=$NEW_RELEASE" >> "$GITHUB_OUTPUT"
+
+          # Use API to update the semantic version variable found in our repository actions variables
+          echo "::group::Update Semantic Version Variable via API"
+          UPDATE_SEMANTIC_VERSION_DATA=$(jq -c -n '{"name":"OPENHORIZON_RELEASE_VERSION","value":$NEW_RELEASE}' --arg NEW_RELEASE "${NEW_RELEASE}")
+
+          STATUS_CHECK_UPDATE_VARIABLE=$( \
+            curl -L \
+              -w "%{http_code}\\n" \
+              -X PATCH \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${OPENHORIZON_RELEASE_MANAGER_TOKEN}" \
+              -H "X-GitHub-Api-Version: ${GITHUB_REST_API_VERSION}" \
+              https://api.github.com/repos/${{ github.repository }}/actions/variables/OPENHORIZON_RELEASE_VERSION \
+              -d "${UPDATE_SEMANTIC_VERSION_DATA}")
+
+          if [[ "${STATUS_CHECK_UPDATE_VARIABLE}" != *"204"* ]]; then
+            echo "::error title=Failed API Call::Update Open Horizon Semantic Version API call returned bad status code"
+            echo -e "Status:\n${STATUS_CHECK_UPDATE_VARIABLE}"
+            exit 1
+          fi
+          echo "::endgroup::"
+        shell: bash
+        env:
+          OPENHORIZON_RELEASE_VERSION: ${{ vars.OPENHORIZON_RELEASE_VERSION }}
+          INCREMENT_MAJOR_VERSION: ${{ github.event.inputs.INCREMENT_MAJOR_VERSION }}
+          INCREMENT_MINOR_VERSION: ${{ github.event.inputs.INCREMENT_MINOR_VERSION }}
+          INCREMENT_PATCH_VERSION: ${{ github.event.inputs.INCREMENT_PATCH_VERSION }}
+
+      # Check if the semantic version has already been released, this typically will throw an error if the user doesn't set the version to increment and the release already exists
+      - name: Check if Open Horizon Release Already Exists
+        run: |
+          echo "::group::Check if Release Already Exists for Version via API"
+          RELEASE_STATUS=$(
+            curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${OPENHORIZON_RELEASE_MANAGER_TOKEN}" \
+              -H "X-GitHub-Api-Version: ${{ env.GITHUB_REST_API_VERSION }}" \
+              'https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.update_version.outputs.NEW_RELEASE }}' \
+              | jq -r '.html_url')
+          
+          sleep 10
+
+          if [[ $RELEASE_STATUS != 'null' ]]; then
+            echo "::error title=Release Already Exists::Attempted to create a release for ${{ steps.update_version.outputs.NEW_RELEASE }}, a version of Open Horizon that already has a release page, see $RELEASE_STATUS"
+            echo "::notice::Consider incrementing the Open Horizon version or deleting the preexisting release"
+            exit 1
+          fi
+          echo "::endgroup::"
+        env:
+          OPENHORIZON_RELEASE_VERSION: ${{ vars.OPENHORIZON_RELEASE_VERSION }}
+
+      # Trigger the Anax Release Manager Workflow (release.yml) to generate the Anax Release
+      - name: Trigger Anax Release Manager
+        run: |
+          # Check if Anax Release Already Exists
+          echo "::group::Check if Anax Release Already Exists via API"
+          RELEASE_STATUS=$(
+            curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${OPENHORIZON_RELEASE_MANAGER_TOKEN}" \
+              -H "X-GitHub-Api-Version: ${{ env.GITHUB_REST_API_VERSION }}" \
+              'https://api.github.com/repos/${{ env.ANAX_REPOSITORY_OWNER }}/${{ env.ANAX_REPOSITORY_NAME }}/releases/tags/v${{ env.AGBOT_VERSION }}' \
+              | jq -r '.html_url')
+          
+          sleep 10
+
+          if [[ $RELEASE_STATUS != 'null' ]]; then
+            echo "::warning title=Anax Release v${{ env.AGBOT_VERSION }} Exists::Attempted to create a release for a version of Anax that already has a release page, see $RELEASE_STATUS"
+            echo "::notice::Release process will continue without triggering a new Anax release, existing release will be linked to this Open Horizion version"
+            exit 0
+          fi
+          echo "::endgroup::"
+
+          sleep 10
+
+          # Get Anax Release Environment ID
+          echo "::group::Get Anax Release Environment ID via API"
+          ANAX_RELEASE_ENVIRONMENT_ID=$( \
+            curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${OPENHORIZON_RELEASE_MANAGER_TOKEN}" \
+              -H "X-GitHub-Api-Version: ${{ env.GITHUB_REST_API_VERSION }}" \
+              'https://api.github.com/repos/${{ env.ANAX_REPOSITORY_OWNER }}/${{ env.ANAX_REPOSITORY_NAME }}/environments/${{ env.ANAX_RELEASE_ENVIRONMENT_NAME }}' \
+              | \
+              jq -r '.id')
+      
+          if [[ -z "$ANAX_RELEASE_ENVIRONMENT_ID" ]]; then
+            echo "::error title=Failed API Call::Failed to get Anax Release Environment ID, check API Call"
+            exit 1
+          fi
+          echo "::endgroup::"
+      
+          # Trigger Anax Release Manager
+          echo "::group::Trigger Anax Release Manager via API"
+          STATUS_CHECK_ONE=$( \
+            curl -L \
+              -w "%{http_code}\\n" \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${OPENHORIZON_RELEASE_MANAGER_TOKEN}" \
+              -H "X-GitHub-Api-Version: ${{ env.GITHUB_REST_API_VERSION }}" \
+              'https://api.github.com/repos/${{ env.ANAX_REPOSITORY_OWNER }}/${{ env.ANAX_REPOSITORY_NAME }}/actions/workflows/${{ env.ANAX_RELEASE_MANAGER_FILE_NAME }}/dispatches' \
+              -d '{"ref":"${{ env.ANAX_RELEASE_MANAGER_BRANCH }}","inputs":{"AGBOT_VERSION": "${{ env.AGBOT_VERSION }}","ANAX_VERSION": "${{ env.ANAX_VERSION }}","ANAX_K8S_VERSION": "${{ env.ANAX_K8S_VERSION }}","ANAX_CSS_VERSION": "${{ env.ANAX_CSS_VERSION }}","ANAX_ESS_VERSION": "${{ env.ANAX_ESS_VERSION }}","IS_LATEST": "${{ env.IS_LATEST }}"}}')
+
+          if [[ "${STATUS_CHECK_ONE}" != *"204"* ]]; then
+            echo "::error title=Failed API Call::Anax workflow dispatch API call returned bad status code"
+            echo -e "Status:\n${STATUS_CHECK_ONE}"
+            exit 1
+          fi
+          echo "::endgroup::"
+
+          sleep 30
+
+          # List most recent triggered workflows that are waiting for a deployment review, use jq to filter down to release runs created today
+          echo "::group::Get Anax Release Run ID via API"
+          ANAX_RELEASE_RUN_ID=$( \
+            curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${OPENHORIZON_RELEASE_MANAGER_TOKEN}" \
+              -H "X-GitHub-Api-Version: ${{ env.GITHUB_REST_API_VERSION }}" \
+              'https://api.github.com/repos/${{ env.ANAX_REPOSITORY_OWNER }}/${{ env.ANAX_REPOSITORY_NAME }}/actions/runs?status=waiting&event=workflow_dispatch&per_page=10&page=1' \
+              | \
+              jq -r '[.workflow_runs[] | select( .path == ".github/workflows/${{ env.ANAX_RELEASE_MANAGER_FILE_NAME }}" )][0].id')
+
+          if [[ -z "$ANAX_RELEASE_RUN_ID" ]]; then
+            echo "::error title=Failed API Call::Failed to get Anax Release Run ID, check API Call"
+            exit 1
+          fi
+          echo "::endgroup::"
+
+          sleep 30
+
+          # Approve workflow run automatically as this workflow run was approved
+          echo "::group::Approve Anax Release Workflow Dispatch via API"
+          ACCEPT_ANAX_RELEASE_API_CALL_DATA=$(jq -c -n '{"environment_ids":[$ARGS.positional[]],"state":"approved","comment":"Triggered automatically via approval from open-horizon/release"}' --jsonargs $ANAX_RELEASE_ENVIRONMENT_ID)
+
+          STATUS_CHECK_TWO=$( \
+            curl -L \
+              -w "%{http_code}\\n" \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${OPENHORIZON_RELEASE_MANAGER_TOKEN}" \
+              -H "X-GitHub-Api-Version: ${{ env.GITHUB_REST_API_VERSION }}" \
+              "https://api.github.com/repos/${{ env.ANAX_REPOSITORY_OWNER }}/${{ env.ANAX_REPOSITORY_NAME }}/actions/runs/${ANAX_RELEASE_RUN_ID}/pending_deployments" \
+              -d "${ACCEPT_ANAX_RELEASE_API_CALL_DATA}")
+          
+          if [[ "${STATUS_CHECK_TWO}" != *"200"* ]]; then
+            echo "::error title=Failed API Call::Anax approve workflow dispatch API call returned bad status code"
+            echo -e "Status:\n${STATUS_CHECK_TWO}"
+            exit 1
+          fi
+          echo "::endgroup::"
+
+          sleep 30
+
+          # Wait until the Anax Release Manager has Complete
+          echo "::group::Check and Wait for Anax Release Manager to Complete via API"
+          check_status () {
+          ANAX_RELEASE_STATUS=$( \
+            curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${OPENHORIZON_RELEASE_MANAGER_TOKEN}"\
+              -H "X-GitHub-Api-Version: ${{ env.GITHUB_REST_API_VERSION }}" \
+              "https://api.github.com/repos/${{ env.ANAX_REPOSITORY_OWNER }}/${{ env.ANAX_REPOSITORY_NAME }}/actions/runs/${ANAX_RELEASE_RUN_ID}" \
+              | \
+              jq -r '.status')
+          }
+
+          max_iterations=5
+          check_status
+          while [[ "${ANAX_RELEASE_STATUS}" != "completed" ]]; do
+            sleep 360 #Release manager typically takes around 5.5 minutes
+            check_status
+            max_iterations=$((max_iterations-1))
+            echo "Status Check Complete, Remaining Opportunities ${max_iterations}/5"
+            if [[ "$max_iterations" -le "0" ]]; then
+              echo "::error title=Anax Release Stuck::Anax Release Manager seems to be stuck, status won't hit completion"
+              exit 1
+            fi
+          done
+          echo "Status was marked completed, moving on."
+          echo "::endgroup::"
+
+          sleep 30
+
+          # Confirm that the workflow in the Anax repo ran successfully
+          echo "::group::Get Success Status of Anax Release Workflow via API"
+          ANAX_RELEASE_CONCLUSION=$( \
+              curl -L \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${OPENHORIZON_RELEASE_MANAGER_TOKEN}"\
+                -H "X-GitHub-Api-Version: ${{ env.GITHUB_REST_API_VERSION }}" \
+                "https://api.github.com/repos/${{ env.ANAX_REPOSITORY_OWNER }}/${{ env.ANAX_REPOSITORY_NAME }}/actions/runs/${ANAX_RELEASE_RUN_ID}" \
+                | \
+                jq -r '.conclusion')
+          
+          if [[ "${ANAX_RELEASE_CONCLUSION}" != "success" ]]; then
+              echo "::error title=Anax Release Failed::Anax Release Manager appears to have failed, been cancelled, or the API call failed"
+              exit 1
+          fi
+          echo "::endgroup::"
+        shell: bash
+        env:
+          AGBOT_VERSION: ${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_agbot }}
+          ANAX_VERSION: ${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_anax }}
+          ANAX_K8S_VERSION: ${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_anax_k8s }}
+          ANAX_CSS_VERSION: ${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_cloud-sync-service }}
+          ANAX_ESS_VERSION: ${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_edge-sync-service }}
+          IS_LATEST: ${{ github.event.inputs.IS_LATEST }}
+
+      # Trigger the Examples Release Manager Workflow (release.yml) to generate the Examples Release
+      - name: Trigger Examples Release Manager
+        run: |
+          # Check if Examples Release Already Exists
+          echo "::group::Check if Examples Release Already Exists"
+          RELEASE_STATUS=$(
+            curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${OPENHORIZON_RELEASE_MANAGER_TOKEN}" \
+              -H "X-GitHub-Api-Version: ${{ env.GITHUB_REST_API_VERSION }}" \
+              'https://api.github.com/repos/${{ env.EXAMPLES_REPOSITORY_OWNER }}/${{ env.EXAMPLES_REPOSITORY_NAME }}/releases/tags/v${{ env.AGBOT_VERSION }}' \
+              | jq -r '.html_url')
+          
+          sleep 10
+
+          if [[ $RELEASE_STATUS != 'null' ]]; then
+            echo "::warning title=Examples Release v${{ env.AGBOT_VERSION }} Exists::Attempted to create a release for a version of Examples that already has a release page, see $RELEASE_STATUS"
+            echo "::notice::Release process will continue without triggering a new Examples release, existing release will be linked to this Open Horizion version"
+            exit 0
+          fi
+          echo "::endgroup::"
+
+          sleep 10
+
+          # Get Examples Release Environment ID
+          echo "::group::Get Examples Release Environment ID via API"
+          EXAMPLES_RELEASE_ENVIRONMENT_ID=$( \
+            curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${OPENHORIZON_RELEASE_MANAGER_TOKEN}" \
+              -H "X-GitHub-Api-Version: ${{ env.GITHUB_REST_API_VERSION }}" \
+              'https://api.github.com/repos/${{ env.EXAMPLES_REPOSITORY_OWNER }}/${{ env.EXAMPLES_REPOSITORY_NAME }}/environments/${{ env.EXAMPLES_RELEASE_ENVIRONMENT_NAME }}' \
+              | \
+              jq -r '.id')
+
+          if [[ -z "$EXAMPLES_RELEASE_ENVIRONMENT_ID" ]]; then
+            echo "::error title=Failed API Call::Failed to get Examples Release Environment ID, check API Call"
+            exit 1
+          fi
+          echo "::endgroup::"
+
+          # Trigger Examples Release Manager
+          echo "::group::Trigger Examples Release Manager via API"
+          TRIGGER_EXAMPLES_RELEASE_API_CALL_DATA=$(jq -c -n '{"ref":"${{ env.EXAMPLES_RELEASE_MANAGER_BRANCH }}","inputs":{"versionFileJSON": $jsonpayload}}' --arg jsonpayload "${JSON_PAYLOAD//\"/\"}")
+
+          STATUS_CHECK_ONE=$( \
+            curl -L \
+              -w "%{http_code}\\n" \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${OPENHORIZON_RELEASE_MANAGER_TOKEN}" \
+              -H "X-GitHub-Api-Version: ${{ env.GITHUB_REST_API_VERSION }}" \
+              https://api.github.com/repos/${{ env.EXAMPLES_REPOSITORY_OWNER }}/${{ env.EXAMPLES_REPOSITORY_NAME }}/actions/workflows/${{ env.EXAMPLES_RELEASE_MANAGER_FILE_NAME }}/dispatches \
+              -d "${TRIGGER_EXAMPLES_RELEASE_API_CALL_DATA}")
+
+          if [[ "${STATUS_CHECK_ONE}" != *"204"* ]]; then
+            echo "::error title=Failed API Call::Examples workflow dispatch API call returned bad status code"
+            echo -e "Status:\n${STATUS_CHECK_ONE}"
+            exit 1
+          fi
+          echo "::endgroup::"
+
+          sleep 30
+
+          # List most recent triggered workflows that are waiting for a deployment review, use jq to filter down to release runs created today
+          echo "::group::Get Examples Release Run ID via API"
+          EXAMPLES_RELEASE_RUN_ID=$( \
+            curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${OPENHORIZON_RELEASE_MANAGER_TOKEN}" \
+              -H "X-GitHub-Api-Version: ${{ env.GITHUB_REST_API_VERSION }}" \
+              'https://api.github.com/repos/${{ env.EXAMPLES_REPOSITORY_OWNER }}/${{ env.EXAMPLES_REPOSITORY_NAME }}/actions/runs?status=waiting&event=workflow_dispatch&per_page=10&page=1' \
+              | \
+              jq -r '[.workflow_runs[] | select( .path == ".github/workflows/${{ env.EXAMPLES_RELEASE_MANAGER_FILE_NAME }}" )][0].id')
+
+          if [[ -z "$EXAMPLES_RELEASE_RUN_ID" ]]; then
+            echo "::error title=Failed API Call::Failed to get Examples Release Run ID, check API Call"
+            exit 1
+          fi
+          echo "::endgroup::"
+
+          sleep 30
+
+          # Approve workflow run automatically as this workflow run was approved
+          echo "::group::Approve Examples Release Workflow Dispatch via API"
+          ACCEPT_EXAMPLES_RELEASE_API_CALL_DATA=$(jq -c -n '{"environment_ids":[$ARGS.positional[]],"state":"approved","comment":"Triggered automatically via approval from open-horizon/release"}' --jsonargs $EXAMPLES_RELEASE_ENVIRONMENT_ID)
+
+          STATUS_CHECK_TWO=$( \
+            curl -L \
+              -w "%{http_code}\\n" \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${OPENHORIZON_RELEASE_MANAGER_TOKEN}" \
+              -H "X-GitHub-Api-Version: ${{ env.GITHUB_REST_API_VERSION }}" \
+              "https://api.github.com/repos/${{ env.EXAMPLES_REPOSITORY_OWNER }}/${{ env.EXAMPLES_REPOSITORY_NAME }}/actions/runs/${EXAMPLES_RELEASE_RUN_ID}/pending_deployments" \
+              -d "${ACCEPT_EXAMPLES_RELEASE_API_CALL_DATA}")
+          
+          if [[ "${STATUS_CHECK_TWO}" != *"200"* ]]; then
+            echo "::error title=Failed API Call::Examples approve workflow dispatch API call returned bad status code"
+            echo -e "Status:\n${STATUS_CHECK_TWO}"
+            exit 1
+          fi
+          echo "::endgroup::"
+
+          sleep 30
+
+          # Wait until the Examples Release Manager has succeeded
+          echo "::group::Wait for Examples Release Manager to Succeed via API"
+          check_status () {
+          EXAMPLES_RELEASE_STATUS=$( \
+            curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${OPENHORIZON_RELEASE_MANAGER_TOKEN}"\
+              -H "X-GitHub-Api-Version: ${{ env.GITHUB_REST_API_VERSION }}" \
+              "https://api.github.com/repos/${{ env.EXAMPLES_REPOSITORY_OWNER }}/${{ env.EXAMPLES_REPOSITORY_NAME }}/actions/runs/${EXAMPLES_RELEASE_RUN_ID}" \
+              | \
+              jq -r '.status')
+          }
+
+          max_iterations=5
+          check_status
+          while [[ "${EXAMPLES_RELEASE_STATUS}" != "completed" ]]; do
+            sleep 180 #Release manager typically takes around 2.5 minutes
+            check_status
+            max_iterations=$((max_iterations-1))
+            if [[ "$max_iterations" -le "0" ]]; then
+              echo "::error title=Examples Release Manager Stuck::Examples Release Manager seems to be stuck, status won't hit completion"
+              exit 1
+            fi
+          done
+          echo "::endgroup::"
+
+          sleep 30
+
+          echo "::group::Get Success Status of Examples Release Workflow via API"
+          EXAMPLES_RELEASE_CONCLUSION=$( \
+              curl -L \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${OPENHORIZON_RELEASE_MANAGER_TOKEN}"\
+                -H "X-GitHub-Api-Version: ${{ env.GITHUB_REST_API_VERSION }}" \
+                "https://api.github.com/repos/${{ env.EXAMPLES_REPOSITORY_OWNER }}/${{ env.EXAMPLES_REPOSITORY_NAME }}/actions/runs/${EXAMPLES_RELEASE_RUN_ID}" \
+                | \
+                jq -r '.conclusion')
+          
+          if [[ "${EXAMPLES_RELEASE_CONCLUSION}" != "success" ]]; then
+              echo "::error::Examples Release Manager appears to have failed or been cancelled"
+              exit 1
+          fi
+          echo "::endgroup::"
+        shell: bash
+        env:
+          AGBOT_VERSION: ${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_agbot }}
+          JSON_PAYLOAD: ${{ github.event.inputs.VERSION_JSON_FILE }}
+
+      # Create the Open Horizon Release 
+      - name: Create Open Horizon Release
+        run: |
+          cd $RUNNER_TEMP
+          jq -n '{
+            "open_horizon": "${{ steps.update_version.outputs.NEW_RELEASE }}",
+            "anax": 
+              {
+                "agbot": "${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_agbot }}",
+                "anax": "${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_anax }}",
+                "anax_k8s": "${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_anax_k8s }}",
+                "cloud_sync_service": "${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_cloud-sync-service }}",
+                "edge_sync_service": "${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_edge-sync-service }}"
+              },
+            "exchange_api": "${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_exchange-api }}",
+            "vault": "${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_vault }}",
+            "fdo": "${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).fdo-owner-services }}",
+            "sdo": "${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).sdo-owner-services }}"
+          }' > Released_Versions.json
+
+          printf "### Open Horizon ${{ steps.update_version.outputs.NEW_RELEASE }} Release Information
+          
+          **Releases tied to v${{ steps.update_version.outputs.NEW_RELEASE }}** \n
+          - Anax: https://github.com/${{ env.ANAX_REPOSITORY_OWNER }}/anax/releases/tag/v${AGBOT_VERSION}
+          - Examples: https://github.com/${{ env.EXAMPLES_REPOSITORY_OWNER }}/examples/releases/tag/v${AGBOT_VERSION}
+          " > OH_RELEASE.txt
+
+          RELEASE_URL=$( \
+            gh release create v${{ steps.update_version.outputs.NEW_RELEASE }} \
+              ${RUNNER_TEMP}/Released_Versions.json \
+              -t "Open Horizon Release v${{ steps.update_version.outputs.NEW_RELEASE }}" \
+              -F OH_RELEASE.txt)
+
+          echo "## Release Success! :tada:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "[View Release](${RELEASE_URL})" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Versions Included in Release" >> $GITHUB_STEP_SUMMARY
+          echo "- Open Horizion: ${{ steps.update_version.outputs.NEW_RELEASE }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Anax" >> $GITHUB_STEP_SUMMARY
+          echo "  - Agbot: ${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_agbot }}" >> $GITHUB_STEP_SUMMARY
+          echo "  - Anax: ${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_anax }}" >> $GITHUB_STEP_SUMMARY
+          echo "  - Anax K8s: ${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_anax_k8s }}" >> $GITHUB_STEP_SUMMARY
+          echo "  - Cloud Sync Service (CSS): ${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_cloud-sync-service }}" >> $GITHUB_STEP_SUMMARY
+          echo "  - Edge Sync Service (ESS): ${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_edge-sync-service }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Exchange API: ${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_exchange-api }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Vault: ${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_vault }}" >> $GITHUB_STEP_SUMMARY
+          echo "- FDO: ${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).fdo-owner-services }}" >> $GITHUB_STEP_SUMMARY
+          echo "- SDO: ${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).sdo-owner-services }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### JSON Inputted for this Workflow Run" >> $GITHUB_STEP_SUMMARY
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          echo "$(jq -n '${{ github.event.inputs.VERSION_JSON_FILE }}')" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+        env:
+          AGBOT_VERSION: ${{ fromJSON(github.event.inputs.VERSION_JSON_FILE).amd64_agbot }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          GH_HOST: github.com

--- a/README.md
+++ b/README.md
@@ -1,2 +1,100 @@
-# open-horizon-release
-Release repository for Open Horizon artifacts
+<div align="left">
+  <img src="https://github.com/open-horizon/artwork/blob/master/white/open-horizon-white.png" alt="Badge" width="auto" height="50">
+  
+<h1 align="center">Open Horizon Releases</h1>
+
+<p align="center">
+  <a href="https://github.com/open-horizon/Open-Horizon-Release/releases/latest">
+    <img src="https://img.shields.io/github/v/release/open-horizon/Open-Horizon-Release" alt="Release">
+  </a>
+  <a href="https://github.com/open-horizon/Open-Horizon-Release/releases/latest">
+    <img src="https://img.shields.io/github/release-date/open-horizon/Open-Horizon-Release" alt="Release Date">
+  </a>
+</p>
+<p align="center">
+  This repository is dedicated to releasing Open Horizon components and tracking their versions across repositories.
+</p>
+
+## Table of Contents
+
+- [Introduction](#introduction)
+- [Release Manager Workflow](#release-manager-workflow)
+- [Contributing](#contributing)
+- [License](#license)
+
+## Introduction
+
+Open Horizon Releases is a central repository aimed at managing and coordinating the release process for various Open Horizon components. Open Horizon is an open-source, edge-computing platform for managing the service software lifecycle of containerized workloads and related machine learning assets. It enables autonomous management of applications deployed to distributed webscale fleets of edge computing nodes and devices without requiring on-premise administrators.
+
+## Why is this repository important?
+
+We recognize the critical role of a single source of truth. This repository serves as the authoritative reference for version tracking and streamlined release management, consolidating version information from multiple repositories.
+
+The release page within this repository serves as a hub connecting the main Open Horizon version to specific versions and their respective release pages of the individual components. This integration enables easy tracking of component releases that were tested together as part of the main Open Horizon release.
+
+## Release Manager Workflow
+
+The Release Manager Workflow is used for the tagging and releasing of Open Horizon components. It ensures consistency and reliability in the release process. Here's a step-by-step guide on how to use the Release Manager Workflow in this repository:
+
+### 1. Creating a New Release
+
+When it's time to create a new release for any Open Horizon component, follow these steps:
+
+- **Step 1:** Generate your Release Versions JSON, it must include all of the keys within the example below.
+
+```json
+{   
+    "amd64_agbot": "2.31.0-1498",
+    "amd64_anax": "2.31.0-1498",
+    "amd64_anax_k8s": "2.31.0-1498",
+    "amd64_cloud-sync-service": "1.10.1-1498",
+    "amd64_edge-sync-service": "1.10.1-1498",
+    "amd64_exchange-api": "2.117.0-1163",
+    "amd64_vault": "1.1.2-806",
+    "fdo-owner-services": "2.31.0-1498",
+    "sdo-owner-services": "1.11.16-1083"
+}
+```
+
+- **Step 2:** Navigate to the [Release Manager Workflow Page](https://github.com/open-horizon/Open-Horizon-Release/actions/workflows/release.yml)
+
+- **Step 3:** Click 'Run Workflow'.
+
+- **Step 4:** Paste your Release Versions JSON into the parameter field.
+
+- **Step 5:** Determine and select how the main Open Horizon Version should be incremented.
+
+- **Step 6:** Hit the green 'Run Workflow' button.
+
+- **Step 7:** Wait for the release to be approved by one of the specific contributors that controls the release management process.
+
+### 2. Release Workflow Runtime Processes
+
+- **Step 1:** Trigger Anax Release Manager.
+  - Triggers the release.yml workflow within the Anax repository via GitHub's REST API, passes artifact versions from the Release Version JSON
+  - Anax release manager pulls artifacts from its build-push.yml workflow, promotes docker images, and creates the release page for Anax
+  - Waits for successful completion of the Anax release.yml workflow (checked via API)
+ 
+- **Step 2:** Trigger Examples Release Manager.
+  - Triggers the release.yml workflow within the Examples repository via GitHub's REST API, passes the entire Release Version JSON
+  - Examples release manager creates the tested versions file and release page
+  - Waits for successful completion of the Examples release.yml workflow (checked via API)
+ 
+- **Step 3:** Increment Open Horizon Version.
+  - Depending on the select option when starting the workflow, we will increment our main Open Horzion semantic version.
+  - If major version is incremented, the minor and patch version are set to 0
+  - If minor version is incremented, the patch version is set to 0
+ 
+- **Step 4:** Create Open Horizon Release.
+  - Creates the release page in this repository with a file that contains the released versions and links to the releases created in Open Horizon component repositories that are tied to the version of Open Horizon just released.
+ 
+### 3. Celebrate New Open Horizon Release!
+
+## Contributing
+
+Contributions to Open Horizon Releases are welcome! If you have suggestions, bug reports, or want to contribute to the release process, please follow the guidelines in [CONTRIBUTING.md](https://github.com/open-horizon/.github/blob/master/CONTRIBUTING.md).
+
+## License
+
+This project is licensed under the Apache License 2.0. See [LICENSE](LICENSE) for more details.
+


### PR DESCRIPTION
## Changes

- Set-Up the ReadMe file with all the necessary information
- Add the main release manager workflow.

## Necessary Settings

- Variables & Secrets
   - Variables
      - `OPENHORIZON_RELEASE_VERSION` - The current version of Open Horizon, probably start at 1.0.0
   - Secrets
      - `OPENHORIZON_RELEASE_MANAGER_TOKEN` - GitHub token that has organization level 'repo' scope. Needs at minimum 'repo' for Open Horizon Release, Anax, and Examples.

- Environments
_(Found in Repo Settings -> Code and Automation -> Environments -> New Environment_
   - Configure `release_environment` with `Required Reviewers` on and list at minimum 1 reviewer. Confirm the setting `Allow administrators to bypass configured protection rules` is off.